### PR TITLE
Update Base-Images & Update Build-Deploy Script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.7-1037 as builder
+FROM registry.access.redhat.com/ubi8/ubi:8.7-1112 as builder
 
 RUN yum -y module enable nodejs:14
 RUN dnf install npm patch -y
@@ -18,7 +18,7 @@ COPY src/ src/
 
 RUN yarn build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1031
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
 
 ENV NGINX_CONFIGURATION_PATH=/etc/nginx/nginx.conf
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -21,3 +21,9 @@ docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
 docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+
+# If the "security-compliance" branch is used for the build, it will tag the image as such.
+if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:security-compliance"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:security-compliance"
+fi

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,6 +4,7 @@ set -exv
 
 IMAGE="quay.io/cloudservices/clowder-plugin"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -24,6 +25,6 @@ docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
 
 # If the "security-compliance" branch is used for the build, it will tag the image as such.
 if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:security-compliance"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:security-compliance"
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
 fi


### PR DESCRIPTION
This PR is to update the `UBI8` and `UBI8-Minimal` Base-Images used for Clowder-Plugin to patch vulnerabilities. Additionally, the `build_deploy.sh` script has been updated to support conditional image tagging based on whether the `security-compliance` branch is being used during the automated build pipeline.  