### PR TITLE
Update Build-Deploy Script to Support New SC Tagging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881 as builder
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1009 as builder
 
 RUN yum -y module enable nodejs:14
 RUN dnf install npm patch -y
@@ -18,7 +18,7 @@ COPY src/ src/
 
 RUN yarn build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1697626218
 
 ENV NGINX_CONFIGURATION_PATH=/etc/nginx/nginx.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1009 as builder
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1072.1697626218 as builder
 
 RUN yum -y module enable nodejs:14
 RUN dnf install npm patch -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1072.1697626218 as builder
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881 as builder
 
 RUN yum -y module enable nodejs:14
 RUN dnf install npm patch -y

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,7 +4,7 @@ set -exv
 
 IMAGE="quay.io/cloudservices/clowder-plugin"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
-SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)"
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -16,15 +16,14 @@ if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
     exit 1
 fi
 
+# If the "security-compliance" branch is used for the build, it will tag the image as such.
+if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
+    IMAGE_TAG="$SECURITY_COMPLIANCE_TAG"
+fi
+
 DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
 docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
-
-# If the "security-compliance" branch is used for the build, it will tag the image as such.
-if [[ $GIT_BRANCH == *"security-compliance"* ]]; then
-    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
-    docker --config="$DOCKER_CONF" push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
-fi


### PR DESCRIPTION
This PR updates the `build_deploy` script to checks if the current Git branch `$GIT_BRANCH` is `origin/security-compliance`. If the condition is true, meaning the current branch is `origin/security-compliance`, it sets the `IMAGE_TAG` variable to the value of `SECURITY_COMPLIANCE_TAG`, and will tag the built container image appropriately to support the creation of Security-Compliance Images. 

Additionally, the `SECURITY_COMPLIANCE_TAG` format has been updated.