### PR TITLE
Update oc-manifest.yaml

### DIFF
--- a/oc-manifest.yaml
+++ b/oc-manifest.yaml
@@ -80,6 +80,7 @@ objects:
   metadata:
     name: clowder-plugin
   spec:
+    type: Service
     displayName: 'OpenShift Console Demo Plugin'
     service:
       name: clowder-plugin


### PR DESCRIPTION
Apparently now we have to define the type

E0416 12:06:33.137527 1 configmap.go:188] unknown backend type for "clowder-plugin" plugin: "". Currently only "Service" backend type is supported.