### PR TITLE
setting node engine to 20 or 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@console/dynamic-demo-plugin",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": "20 || 22" 
+  },
   "scripts": {
     "pre-build": "rm -rf ./dist && yarn install",
     "build": "yarn pre-build & NODE_ENV=production webpack --config webpack.config.mjs",


### PR DESCRIPTION
# Purpose

Our build job is failing with the following error:
```
error undici@7.10.0: The engine "node" is incompatible with this module. Expected version ">=20.18.1". Got "18.20.6"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
subprocess exited with status 1
```
This PR will set the node engine to be at least 20.