### PR TITLE
fix: update UBI9 base images to 9.8 for CVE remediation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.7-1778044007 AS builder
+FROM registry.access.redhat.com/ubi9/ubi:9.8-1782121068 AS builder
 
 RUN yum -y module enable nodejs:20
 RUN dnf install npm patch -y
@@ -18,7 +18,7 @@ COPY src/ src/
 
 RUN yarn build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778072020
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
 
 ENV NGINX_CONFIGURATION_PATH=/etc/nginx/nginx.conf
 


### PR DESCRIPTION
Update builder and runtime base images from UBI 9.7 to 9.8 to resolve RPM-based vulnerabilities including critical gnutls, high-severity glibc, openssl, libarchive, and other system package CVEs.