### PR TITLE
glasswing: fix f001 — registry credentials leaked to CI logs via shell xtrace

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -23,7 +23,11 @@ fi
 
 DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
-docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+# Disable xtrace and pass passwords via stdin so registry tokens are never
+# expanded into the CI log stream or process argv (CWE-532 / CWE-214).
+set +x
+docker --config="$DOCKER_CONF" login -u="$QUAY_USER" --password-stdin quay.io <<<"$QUAY_TOKEN"
+docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" --password-stdin registry.redhat.io <<<"$RH_REGISTRY_TOKEN"
+set -x
 docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"


### PR DESCRIPTION
build_deploy.sh runs under `set -exv`; the `-x` flag prints each command after parameter expansion, so the `docker login -p="$QUAY_TOKEN"` and `-p="$RH_REGISTRY_TOKEN"` invocations emitted the literal push tokens to stderr, which the legacy App-Interface Jenkins job captures into its build log. Disable xtrace around the two login calls and switch to `--password-stdin` so the secrets never appear in the traced command line or process argv, while preserving xtrace for the remainder of the script.

Addresses: analysis-results/findings/clowder/clowder-plugin/clowder-plugin-triage.json#f001
CWEs: CWE-532, CWE-214